### PR TITLE
Added ability to add user to api container

### DIFF
--- a/api/start.sh
+++ b/api/start.sh
@@ -81,4 +81,10 @@ EOF
 
 cd /opt/nodepki
 npm install
-node server.js 
+
+if [ ! -s /opt/nodepki/data/user.db ]; then
+  echo "Adding user to the database"
+  nodejs nodepkictl useradd --username ${WEBUI_USER} --password ${WEBUI_PASS}
+fi
+
+node server.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - STATE_NAME=the
       - LOCALITY_NAME=in
       - ORGANIZATION_NAME=somewhere
+      - WEBUI_USER=admin
+      - WEBUI_PASS=admin
   web:
     image: nodepki-webclient:7.0
     environment: 


### PR DESCRIPTION
It took me a long time to figure out how to authenticate to the web ui. After inspecting the container, I figured out that my users database was empty. This PR is giving you an ability to create a web ui user at container instantiation. Default creds are `admin/admin`